### PR TITLE
feat: add user registration endpoint with validation and tests

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
 from backend.models.user import User
 from backend.database import db
+import re
 
 auth_bp = Blueprint('auth', __name__)
 
@@ -12,6 +13,16 @@ def register():
     # Validate input
     if not data.get('username') or not data.get('email') or not data.get('password'):
         return jsonify({'error': 'Missing required fields'}), 400
+
+    # Email format validation
+    email_regex = r"^[\w\.-]+@[\w\.-]+\.\w+$"
+    if not re.match(email_regex, data['email']):
+        return jsonify({'error': 'Invalid email format'}), 400
+
+    # Password strength validation
+    password = data['password']
+    if len(password) < 8 or not re.search(r"[A-Za-z]", password) or not re.search(r"\d", password):
+        return jsonify({'error': 'Password must be at least 8 characters long and contain both letters and numbers'}), 400
     
     # Check if user exists
     if User.query.filter_by(email=data['email']).first():
@@ -61,3 +72,6 @@ def get_profile():
         return jsonify(user.to_dict()), 200
     
     return jsonify({'error': 'User not found'}), 404
+
+# For testing convenience
+bp = auth_bp

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -72,6 +72,3 @@ def get_profile():
         return jsonify(user.to_dict()), 200
     
     return jsonify({'error': 'User not found'}), 404
-
-# For testing convenience
-bp = auth_bp

--- a/backend/test_auth.py
+++ b/backend/test_auth.py
@@ -1,0 +1,66 @@
+import pytest
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from backend.app import create_app
+from backend.models.user import User
+from backend.database import db
+import json
+from config import TestingConfig
+
+@pytest.fixture
+def client():
+    app = create_app(TestingConfig)
+    with app.test_client() as client:
+        with app.app_context():
+            db.create_all()
+        yield client
+        with app.app_context():
+            db.drop_all()
+
+def register(client, username, email, password):
+    return client.post('/register', json={
+        'username': username,
+        'email': email,
+        'password': password
+    })
+
+def test_successful_registration(client):
+    resp = register(client, 'user1', 'user1@example.com', 'Password123')
+    data = resp.get_json()
+    assert resp.status_code == 201
+    assert 'access_token' in data
+    assert data['user']['username'] == 'user1'
+
+def test_missing_fields(client):
+    resp = register(client, '', 'user2@example.com', 'Password123')
+    assert resp.status_code == 400
+    resp = register(client, 'user2', '', 'Password123')
+    assert resp.status_code == 400
+    resp = register(client, 'user2', 'user2@example.com', '')
+    assert resp.status_code == 400
+
+def test_invalid_email(client):
+    resp = register(client, 'user3', 'invalidemail', 'Password123')
+    assert resp.status_code == 400
+    assert 'Invalid email format' in resp.get_json()['error']
+
+def test_weak_password(client):
+    resp = register(client, 'user4', 'user4@example.com', 'short')
+    assert resp.status_code == 400
+    resp = register(client, 'user4', 'user4@example.com', 'allletters')
+    assert resp.status_code == 400
+    resp = register(client, 'user4', 'user4@example.com', '12345678')
+    assert resp.status_code == 400
+
+def test_duplicate_email(client):
+    register(client, 'user5', 'user5@example.com', 'Password123')
+    resp = register(client, 'user6', 'user5@example.com', 'Password123')
+    assert resp.status_code == 400
+    assert 'Email already registered' in resp.get_json()['error']
+
+def test_duplicate_username(client):
+    register(client, 'user7', 'user7@example.com', 'Password123')
+    resp = register(client, 'user7', 'user8@example.com', 'Password123')
+    assert resp.status_code == 400
+    assert 'Username already taken' in resp.get_json()['error'] 

--- a/config.py
+++ b/config.py
@@ -19,8 +19,14 @@ class DevelopmentConfig(Config):
 class ProductionConfig(Config):
     DEBUG = False
 
+class TestingConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    DEBUG = True
+
 config = {
     'development': DevelopmentConfig,
     'production': ProductionConfig,
+    'testing': TestingConfig,
     'default': DevelopmentConfig
 }


### PR DESCRIPTION
## Description

This PR implements the `/api/auth/register` endpoint for user registration as described in issue #3.

### Features
- Adds a POST endpoint for user registration at `/api/auth/register`
- Validates required fields, email format, and password strength
- Checks for duplicate usernames and emails
- Hashes passwords before storing them in the database
- Returns appropriate JSON success and error responses
- Includes unit tests covering all acceptance criteria

### Notes
- This PR is from my fork’s `main` branch because I accidentally pushed the changes there. Sorry for the process deviation!
- Please let me know if any further changes are needed.

Closes #3